### PR TITLE
Added Catalyst

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 * [PyTorchNet](https://github.com/pytorch/tnt) - An abstraction to train neural networks. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 * [Aorun](https://github.com/ramon-oliveira/aorun) - Intend to implement an API similar to Keras with PyTorch as backend. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 * [pytorch_geometric](https://github.com/rusty1s/pytorch_geometric) - Geometric Deep Learning Extension Library for PyTorch. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
+* [Catalyst](https://github.com/catalyst-team/catalyst) - High-level utils for PyTorch DL & RL research. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 
 ### TensorFlow
 * [TensorFlow](https://github.com/tensorflow/tensorflow) - Computation using data flow graphs for scalable machine learning by Google. <img height="20" src="img/tf_big2.png" alt="sklearn">

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,7 @@
 * [PyTorchNet](https://github.com/pytorch/tnt) - An abstraction to train neural networks <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 * [Aorun](https://github.com/ramon-oliveira/aorun) - Intend to implement an API similar to Keras with PyTorch as backend. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 * [pytorch_geometric](https://github.com/rusty1s/pytorch_geometric) - Geometric Deep Learning Extension Library for PyTorch. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
+* [Catalyst](https://github.com/catalyst-team/catalyst) - High-level utils for PyTorch DL & RL research. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 
 <a name="dl-tf"></a>
 ### TensorFlow


### PR DESCRIPTION
Hi! I'm a developer of the [Catalyst framework](https://github.com/catalyst-team/catalyst) for Deep Leaning on PyTorch. I would like to add a link to your list. We actively support the project and create a new release every month.

The data scientists community likes Catalyst. It is actively used for competitions on Kaggle. PyTorch has also added us to [its ecosystem](https://pytorch.org/ecosystem/).