### PR TITLE
Add nancorrmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@
 * [numdifftools](https://github.com/pbrod/numdifftools) - Solve automatic numerical differentiation problems in one or more variables.
 * [quaternion](https://github.com/moble/quaternion) - Add built-in support for quaternions to numpy.
 * [adaptive](https://github.com/python-adaptive/adaptive) - Tools for adaptive and parallel samping of mathematical functions.
+* [nancorrmp](https://github.com/bukson/nancorrmp) - Parallel correlation calculation for huge matrices with NaNs and infs
 
 ## Spatial Analysis
 * [GeoPandas](https://github.com/geopandas/geopandas) - Python tools for geographic data. <img height="20" src="img/pandas_big.png" alt="pandas compatible">


### PR DESCRIPTION
Add library for parallel correlation calculation for matrices with NaNs and infs.

Default numpy.corrcoef method does not work with nans and infs, pandas DataFrame.corr is single thread only