### PR TITLE
📦 Add link check action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,13 @@
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run linksafe
+        uses: TechWiz-3/linksafe@main
+        with:
+          dirs: ".,./addons,./docs,./other"
+          verbose: true
+          whitelist_files: "./docs/index.html"


### PR DESCRIPTION
In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own action, the repo is [here](https://github.com/TechWiz-3/linksafe)

You can view the logs of the workflow on my fork [here](https://github.com/TechWiz-3/awesome-python-data-science/runs/7595595965?check_suite_focus=true). 9 links were found to be broken. Please note because of the amount of links, the workflow took 30 minutes.

Also, you may note a little bug in the logs ` --> Link validity unkwown with 402 Forbidden return code 403` - this bug has been fixed.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)