### PR TITLE
Adding DataComPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@
 * [deepchecks](https://github.com/deepchecks/deepchecks) - Validation & testing of ML models and data during model development, deployment, and production. <img height="20" src="img/sklearn_big.png" alt="sklearn">
 * [evidently](https://github.com/evidentlyai/evidently) - Evaluate and monitor ML models from validation to production.
 * [TensorFlow Data Validation](https://github.com/tensorflow/data-validation) - Library for exploring and validating machine learning data.
+* [DataComPy](https://github.com/capitalone/datacompy)- A library to compare Pandas, Polars, and Spark data frames. It provides stats and lets users adjust for match accuracy.
 
 ## Evaluation
 * [recmetrics](https://github.com/statisticianinstilettos/recmetrics) - Library of useful metrics and plots for evaluating recommender systems.


### PR DESCRIPTION
Hi there!

Was hoping you might be open to adding in DataComPy a package which I help maintain. I think would fit in nicely in the data validation section.

A brief overview: DataComPy allows users to compare Pandas, Polars, and Spark data frames. It provides stats and lets users adjust for match accuracy, but also provide the details in a human-readable format. Users can also compare across data frame types like Spark vs Polars, Pandas vs Spark etc using Fugue in the backend.

Thanks!
